### PR TITLE
chore: add gh workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 - `npm run test` — Execute workspace-level test commands.
 - `npm run test:coverage` — Compose client and server coverage reports; mirrors the CI gate that fails if either side drops below 80%.
 - `npm run dev:client` / `npm run dev:server` — Focus on a single stack during development.
+- `npm run gh:workflow -- --branch feature/example --commit "feat: add example" --title "feat: add example" --summary "Sentence one. Sentence two."` — Automate the GitHub workflow (branch switch/create, commit, PR creation with summary and optional Mermaid block, approval (best-effort), merge into `main`, and branch cleanup). Requires `gh` CLI plus `GITHUB_TOKEN` and `GITHUB_REPOSITORY` env vars.
 
 ## Environment Configuration
 - Root `.env` / `.env.local` — Shared values consumed by scripts or tooling on both stacks. Start from `.env.example` and keep it updated with required keys.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "server"
       ],
       "devDependencies": {
+        "dotenv": "^16.4.5",
         "npm-run-all": "^4.1.5",
         "typescript": "^5.4.5"
       }
@@ -2934,6 +2935,19 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "test:server": "npm run test --workspace server",
     "test:coverage": "run-s test:coverage:client test:coverage:server",
     "test:coverage:client": "npm run test:coverage --workspace client",
-    "test:coverage:server": "npm run test:coverage --workspace server"
+    "test:coverage:server": "npm run test:coverage --workspace server",
+    "gh:workflow": "node ./scripts/gh-workflow.js"
   },
   "devDependencies": {
+    "dotenv": "^16.4.5",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.4.5"
   }

--- a/scripts/gh-workflow.js
+++ b/scripts/gh-workflow.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+
+const { spawnSync } = require('node:child_process');
+const { env, argv, exit } = require('node:process');
+
+if (!env.GH_PROMPT_DISABLED) {
+  env.GH_PROMPT_DISABLED = '1';
+}
+
+const parseArgs = (input) => {
+  const result = {};
+  for (let i = 0; i < input.length; i += 1) {
+    const token = input[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = input[i + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      i += 1;
+    } else {
+      result[key] = 'true';
+    }
+  }
+  return result;
+};
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    exit(result.status ?? 1);
+  }
+};
+
+const runOptional = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').toString().trim();
+    if (stderr) {
+      console.warn(stderr);
+    }
+    return false;
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+
+  return true;
+};
+
+const capture = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `Command failed: ${command} ${args.join(' ')}`);
+  }
+
+  return (result.stdout || '').trim();
+};
+
+const sentencesIn = (text) => {
+  return text
+    .split(/[.!?]+\s*/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0).length;
+};
+
+const options = parseArgs(argv.slice(2));
+
+const requiredKeys = ['branch', 'commit', 'title', 'summary'];
+const missing = requiredKeys.filter((key) => !options[key]);
+
+if (missing.length > 0) {
+  console.error(`Missing required options: ${missing.join(', ')}`);
+  console.error('Usage: npm run gh:workflow -- --branch <name> --commit <message> --title <pr title> --summary "Sentence one. Sentence two." [--mermaid "graph TD;"] [--base main]');
+  exit(1);
+}
+
+if (!env.GITHUB_TOKEN) {
+  console.error('GITHUB_TOKEN is required for GitHub CLI authentication.');
+  exit(1);
+}
+
+if (!env.GITHUB_REPOSITORY) {
+  console.error('GITHUB_REPOSITORY must be set (e.g. owner/repo).');
+  exit(1);
+}
+
+const summary = options.summary.trim();
+const sentenceCount = sentencesIn(summary);
+
+if (sentenceCount < 2 || sentenceCount > 6) {
+  console.error('Summary must contain between 2 and 6 sentences.');
+  exit(1);
+}
+
+const baseBranch = options.base || 'main';
+const targetBranch = options.branch;
+const repo = env.GITHUB_REPOSITORY;
+
+const ghEnv = {
+  ...env,
+  GH_TOKEN: env.GITHUB_TOKEN,
+};
+
+const status = capture('git', ['status', '--porcelain']);
+if (!status) {
+  console.error('There are no changes to commit.');
+  exit(1);
+}
+
+let branchExists = false;
+try {
+  capture('git', ['rev-parse', '--verify', targetBranch]);
+  branchExists = true;
+} catch (error) {
+  branchExists = false;
+}
+
+if (branchExists) {
+  run('git', ['switch', targetBranch]);
+} else {
+  run('git', ['switch', '-c', targetBranch]);
+}
+
+run('git', ['add', '-A']);
+
+run('git', ['commit', '-m', options.commit]);
+
+run('git', ['push', '-u', 'origin', targetBranch]);
+
+const bodyParts = [summary];
+if (options.mermaid) {
+  bodyParts.push('```mermaid\n' + options.mermaid.trim() + '\n```');
+}
+const prBody = bodyParts.join('\n\n');
+
+run('gh', ['pr', 'create', '--title', options.title, '--body', prBody, '--head', targetBranch, '--base', baseBranch, '--repo', repo], { env: ghEnv });
+
+const prInfoRaw = capture('gh', ['pr', 'view', targetBranch, '--json', 'number', '--repo', repo], { env: ghEnv });
+const prNumber = JSON.parse(prInfoRaw).number;
+
+runOptional('gh', ['pr', 'review', String(prNumber), '--approve', '--repo', repo], { env: ghEnv });
+
+run('gh', ['pr', 'merge', String(prNumber), '--squash', '--delete-branch', '--repo', repo], { env: ghEnv });
+
+run('git', ['switch', baseBranch]);
+run('git', ['pull', '--ff-only', 'origin', baseBranch]);
+
+const localBranches = capture('git', ['branch', '--list', targetBranch]);
+if (localBranches) {
+  run('git', ['branch', '-D', targetBranch]);
+}
+
+console.log(`Merged PR #${prNumber} into ${baseBranch} and cleaned up ${targetBranch}.`);


### PR DESCRIPTION
Introduced a GitHub CLI workflow helper that automates branch creation, PR submission, approval, and merge. Documented usage and wired the helper into package.json for easy access.

```mermaid
graph TD; A[local changes]-->B[gh:workflow]; B-->C[PR created]; C-->D[PR approved]; D-->E[PR merged];
```