### PR TITLE
docs: clarify gh workflow usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,12 @@
 - When modifying `/client` or `/server`, update `/README.md` and any impacted `/docs` pages so they stay accurate and complete.
 - Confirm new docs keep the README table of contents in sync with the `/docs` directory.
 
+## GitHub Workflow Automation
+- Use `npm run gh:workflow` only when the branch is review-ready and automated checks have been run; the script opens, approves (if possible), merges, and cleans up the branch in one pass.
+- Provide a 2-6 sentence summary via `--summary` and optionally attach a Mermaid diagram with `--mermaid` to enrich the PR body.
+- Ensure `.env` (or the shell) supplies `GITHUB_TOKEN` and `GITHUB_REPOSITORY` so the GitHub CLI can authenticate without prompts.
+- The helper performs a squash merge into `main`; avoid running it for work that still needs peer review or multiple commits preserved.
+
 ## Sandbox & Approvals
 - Stay within workspace-write boundaries; request elevation with a clear justification when needed.
 - Avoid destructive commands unless the user explicitly requests them.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 - `npm run dev:client` / `npm run dev:server` — Focus on a single stack during development.
 - `npm run gh:workflow -- --branch feature/example --commit "feat: add example" --title "feat: add example" --summary "Sentence one. Sentence two."` — Automate the GitHub workflow (branch switch/create, commit, PR creation with summary and optional Mermaid block, approval (best-effort), merge into `main`, and branch cleanup). Requires `gh` CLI plus `GITHUB_TOKEN` and `GITHUB_REPOSITORY` env vars.
 
+### Automated PR Workflow
+- Run `npm run gh:workflow` only after local tests, linting, and docs are complete; the helper squash-merges directly into `main` and deletes the feature branch.
+- Required flags: `--branch`, `--commit`, `--title`, and `--summary` (must include 2-6 sentences). Optional `--mermaid "graph TD; ..."` appends a diagram to the PR body. Use `--base` to merge into a different branch when needed.
+- Environment: provide `GITHUB_TOKEN` (with `repo` scope) and `GITHUB_REPOSITORY=owner/name` via `.env` or the shell so the GitHub CLI can authenticate without prompts.
+- The script attempts to approve the PR; GitHub ignores the approval if you are the author, but the merge still succeeds.
+
 ## Environment Configuration
 - Root `.env` / `.env.local` — Shared values consumed by scripts or tooling on both stacks. Start from `.env.example` and keep it updated with required keys.
 - `client/.env` — Frontend-only variables; prefix with `VITE_` so Vite exposes them to the bundle. Mirror required entries in `client/.env.example` with instructional defaults.


### PR DESCRIPTION
Documented when to run the gh workflow helper and which inputs it requires. Updated the root README with an automated PR workflow section so contributors know how to configure the environment.