### PR TITLE
docs: outline client directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 - `/client` — Vite-powered React frontend; see `client/AGENTS.md` for UI practices.
 - `/server` — Express REST API; see `server/AGENTS.md` for backend conventions.
 - `/docs` — Documentation hub with architecture notes, API catalog, release checklists, and templates.
+- Client structure highlights:
+  - `/src/components/` — reusable React components.
+  - `/src/hooks/` — shared custom hooks.
+  - `/src/api/` — modules that fetch data from the backend.
+  - `/src/stores/` — Zustand stores for shared state.
+  - `/src/views/` — top-level routed view components.
 
 ## Getting Started
 1. Install dependencies: `npm install` (the root `package.json` wires up workspaces for client and server).

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -6,6 +6,12 @@
 - Vite-powered React + TypeScript; prefer functional components and hooks.
 - Reach for Zustand when state grows beyond local component scope or multiple routes share data.
 - Keep shared UI primitives in `/client/src/components/common` so they stay discoverable.
+- Project structure expectations:
+  - `/src/components/` — shared and domain components.
+  - `/src/hooks/` — reusable custom hooks.
+  - `/src/api/` — data-fetching clients encapsulating server calls.
+  - `/src/stores/` — Zustand stores plus related selectors/actions.
+  - `/src/views/` — top-level route views that compose components and state.
 
 ## Workflow Expectations
 - Mirror root planning and documentation rules; call out `/docs/frontend` updates in the summary.


### PR DESCRIPTION
Updated the client agent guide with an explicit directory map for components, hooks, API clients, Zustand stores, and routed views. Extended the root README layout section so new contributors understand where frontend pieces belong.