### PR TITLE
feat(server): extract handlers directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 ## Repo Layout
 - `/client` — Vite-powered React frontend; see `client/AGENTS.md` for UI practices.
 - `/server` — Express REST API; see `server/AGENTS.md` for backend conventions.
+- Server routes live in Express `Router` modules (e.g., `server/src/routes/*`) that group handlers by resource and are mounted in the main app for RESTful organization.
+- Server request handlers belong in `server/src/handlers/*` so routing layers stay thin and logic is easy to share.
 - `/docs` — Documentation hub with architecture notes, API catalog, release checklists, and templates.
 - Client structure highlights:
   - `/src/components/` — reusable React components.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -6,6 +6,8 @@
 - TypeScript Express REST API; keep handlers thin and delegate business logic to `/server/src/services`.
 - Enforce RESTful naming and HTTP semantics; document new routes in `/docs/api-surface.md`.
 - Centralise configuration under `/server/src/config`; never hardcode secrets.
+- Define routes inside Express `Router` modules grouped by resource (e.g., `/server/src/routes/users.ts`) and mount them in the main app entrypoint to keep RESTful boundaries clear.
+- Store request handlers in `/server/src/handlers` so routers remain declarative and reusable logic stays isolated from wiring.
 
 ## Workflow Expectations
 - Follow the root planning cadence; surface API contract changes in standups and summaries.

--- a/server/src/handlers/health.ts
+++ b/server/src/handlers/health.ts
@@ -1,0 +1,7 @@
+import type { RequestHandler } from 'express';
+
+export const healthHandler: RequestHandler = (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+};
+
+export default healthHandler;

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
-import { healthHandler } from './index';
+import { healthHandler } from './handlers/health';
 
 type MockResponse = Pick<Response, 'status' | 'json'> & {
   statusCode?: number;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 import cors from 'cors';
 import express from 'express';
-import type { RequestHandler } from 'express';
+import healthRouter from './routes/health';
 
 export const app = express();
 const port = process.env.PORT ?? 3000;
@@ -8,11 +8,7 @@ const port = process.env.PORT ?? 3000;
 app.use(cors());
 app.use(express.json());
 
-export const healthHandler: RequestHandler = (_req, res) => {
-  res.status(200).json({ status: 'ok' });
-};
-
-app.get('/health', healthHandler);
+app.use('/health', healthRouter);
 
 /* c8 ignore start */
 if (process.env.NODE_ENV !== 'test') {

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { healthHandler } from '../handlers/health';
+
+export const healthRouter = Router();
+
+healthRouter.get('/', healthHandler);
+
+export default healthRouter;


### PR DESCRIPTION
Documented handler placement in the server agent guide and root README. Added /server/src/handlers with a dedicated health handler wired into the existing health router. Updated routing imports and unit tests to consume the shared handler module.