### PR TITLE
chore: enforce lint before commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@
 
 ## Delivery Checklist
 - Explain modifications, note testing status (or why tests were skipped), and suggest natural next steps for the user.
+- Ensure `npm run lint` passes (client and server) before committing or handing off work.
 - Call out documentation updates or confirm that docs remain accurate after code changes.
 - Keep the coverage automation green: the workspace CI composes client and server vitest runs and fails when either coverage report drops below 80%; run the root `npm run test:coverage` gate locally before hand-off if coverage may shift.
 - Use the root scripts (`npm run test`, `npm run test:coverage`) to validate changes before hand-off when applicable.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 
 ### Automated PR Workflow
 - Run `npm run gh:workflow` only after local tests, linting, and docs are complete; the helper squash-merges directly into `main` and deletes the feature branch.
+- Make sure `npm run lint` succeeds (calls both client and server lint scripts) before committing or opening a PR.
 - Required flags: `--branch`, `--commit`, `--title`, and `--summary` (must include 2-6 sentences). Optional `--mermaid "graph TD; ..."` appends a diagram to the PR body. Use `--base` to merge into a different branch when needed.
 - Environment: provide `GITHUB_TOKEN` (with `repo` scope) and `GITHUB_REPOSITORY=owner/name` via `.env` or the shell so the GitHub CLI can authenticate without prompts.
 - The script attempts to approve the PR; GitHub ignores the approval if you are the author, but the merge still succeeds.

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Workflow Expectations
 - Mirror root planning and documentation rules; call out `/docs/frontend` updates in the summary.
-- Run `npm run test --workspace client` for component suites when touching shared UI.
+- Run `npm run lint --workspace client` and `npm run test --workspace client` before sending changes for review.
 - Update `/README.md` if new frontend scripts or npm commands are introduced.
 - Keep client environment variables in `client/.env` using the `VITE_` prefix so Vite exposes them safely.
 - When adding or renaming frontend env vars, update `client/.env.example` with placeholder values so onboarding stays smooth.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Workflow Expectations
 - Follow the root planning cadence; surface API contract changes in standups and summaries.
-- Run `npm run test:server` (or the closest backend suite) before handing off changes.
+- Run `npm run lint --workspace server` and `npm run test:server` before handing off changes.
 - Ensure `/README.md` reflects new environment variables or scripts introduced for the backend.
 - Store backend environment variables in `server/.env`; keep secrets out of client-visible locations.
 - Maintain `server/.env.example` with the required keys and safe placeholder values whenever contracts change.

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import { healthHandler } from './handlers/health';
 
 type MockResponse = Pick<Response, 'status' | 'json'> & {
@@ -12,12 +12,12 @@ const createMockResponse = (): MockResponse => {
     status: vi.fn(function status(this: MockResponse, code: number) {
       this.statusCode = code;
       return this;
-    }) as MockResponse['status'],
+    }) as unknown as MockResponse['status'],
     json: vi.fn(function json(this: MockResponse, payload: unknown) {
       this.payload = payload;
       this.statusCode = this.statusCode ?? 200;
       return this;
-    }) as MockResponse['json'],
+    }) as unknown as MockResponse['json'],
   };
 
   return res;
@@ -27,7 +27,9 @@ describe('healthHandler', () => {
   it('returns an ok payload with a 200 status', () => {
     const res = createMockResponse();
 
-    healthHandler({} as Request, res as Response);
+    const next = vi.fn() as unknown as NextFunction;
+
+    healthHandler({} as Request, res as Response, next);
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ status: 'ok' });


### PR DESCRIPTION
Documented the requirement to run npm run lint before handing off work across the root, client, and server guides. Updated the README workflow section and cleaned up the server unit test to satisfy Express typings.