### PR TITLE
feat(server): add ipinfo geolocation enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 ## Environment Configuration
 - Root `.env` / `.env.local` — Shared values consumed by scripts or tooling on both stacks. Start from `.env.example` and keep it updated with required keys.
 - `client/.env` — Frontend-only variables; prefix with `VITE_` so Vite exposes them to the bundle. Mirror required entries in `client/.env.example` with instructional defaults.
-- `server/.env` — Backend-only secrets and configuration read by Express via `process.env` (keep out of client scope). Document mandatory values in `server/.env.example`.
+- `server/.env` — Backend-only secrets and configuration read by Express via `process.env` (keep out of client scope). Document mandatory values in `server/.env.example` (e.g., set `IPINFO_TOKEN` for ipinfo geolocation lookups).
 - `supabase/.env` — Supabase tooling credentials scoped to database automation. Mirror required values in `supabase/.env.example` and keep secrets out of client-visible code.
 - Commit the `*.env.example` files so new contributors can bootstrap quickly without exposing secrets.
 

--- a/docs/backend-operations.md
+++ b/docs/backend-operations.md
@@ -14,6 +14,7 @@
 - Centralize logs with the configured logging provider; scrub sensitive data.
 - Define alerts for latency, error rate, and queue backlogs.
 - Document new dashboards or metrics here with direct links when available.
+- Geolocation enrichment uses ipinfo; set `IPINFO_TOKEN` in `server/.env` and monitor usage against the free-tier quota.
 
 ## Runbooks
 - Capture rollback steps; default to automated rollback if deployment fails.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
 # Backend-only secrets and configuration; copy to server/.env for local development.
 PORT=3000
 DATABASE_URL=postgres://user:password@localhost:5432/app_db
+IPINFO_TOKEN=your_ipinfo_token_here

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,12 +1,14 @@
 import cors from 'cors';
 import express from 'express';
 import healthRouter from './routes/health';
+import attachGeo from './middleware/attachGeo';
 
 export const app = express();
 const port = process.env.PORT ?? 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use(attachGeo);
 
 app.use('/health', healthRouter);
 

--- a/server/src/middleware/attachGeo.ts
+++ b/server/src/middleware/attachGeo.ts
@@ -1,0 +1,28 @@
+import type { RequestHandler } from 'express';
+import { lookupIp, resolveClientIp } from '../services/ipinfo';
+
+export const attachGeo: RequestHandler = async (req, res, next) => {
+  if (!process.env.IPINFO_TOKEN) {
+    return next();
+  }
+
+  const ip = resolveClientIp(req);
+
+  if (!ip) {
+    return next();
+  }
+
+  try {
+    const geo = await lookupIp(ip);
+
+    if (geo) {
+      res.locals.geo = geo;
+    }
+  } catch (error) {
+    console.warn('Failed to enrich request with geolocation data', error);
+  }
+
+  next();
+};
+
+export default attachGeo;

--- a/server/src/services/ipinfo.test.ts
+++ b/server/src/services/ipinfo.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, beforeEach, afterEach, it, vi } from 'vitest';
+import type { IncomingMessage } from 'node:http';
+import { lookupIp, resolveClientIp, clearIpInfoCache } from './ipinfo';
+
+describe('ipinfo service', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    clearIpInfoCache();
+    delete process.env.IPINFO_TOKEN;
+    fetchSpy = undefined;
+  });
+
+  afterEach(() => {
+    clearIpInfoCache();
+    if (fetchSpy) {
+      fetchSpy.mockRestore();
+      fetchSpy = undefined;
+    }
+    delete process.env.IPINFO_TOKEN;
+  });
+
+  it('returns null for private addresses', async () => {
+    process.env.IPINFO_TOKEN = 'test-token';
+    const result = await lookupIp('127.0.0.1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when IPINFO_TOKEN is missing', async () => {
+    const result = await lookupIp('1.1.1.1');
+    expect(result).toBeNull();
+  });
+
+  it('queries ipinfo and caches the result', async () => {
+    process.env.IPINFO_TOKEN = 'test-token';
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ip: '1.1.1.1',
+          city: 'City',
+          region: 'Region',
+          country: 'CC',
+          loc: '12.34,56.78',
+        }),
+      } as unknown as Response);
+
+    const result = await lookupIp('1.1.1.1');
+    expect(result).toEqual({
+      ip: '1.1.1.1',
+      city: 'City',
+      region: 'Region',
+      country: 'CC',
+      latitude: 12.34,
+      longitude: 56.78,
+      source: 'ipinfo',
+      cached: false,
+    });
+
+    const cached = await lookupIp('1.1.1.1');
+    expect(cached).toEqual({
+      ip: '1.1.1.1',
+      city: 'City',
+      region: 'Region',
+      country: 'CC',
+      latitude: 12.34,
+      longitude: 56.78,
+      source: 'ipinfo',
+      cached: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves IP address from headers or socket info', () => {
+    const req = {
+      headers: {
+        'x-forwarded-for': '203.0.113.1, 198.51.100.2',
+      },
+      socket: { remoteAddress: '198.51.100.1' },
+      ip: '198.51.100.3',
+    } as unknown as IncomingMessage & Parameters<typeof resolveClientIp>[0];
+
+    const ip = resolveClientIp(req);
+    expect(ip).toBe('203.0.113.1');
+
+    const reqWithoutHeader = {
+      headers: {},
+      socket: { remoteAddress: '198.51.100.1' },
+      ip: '198.51.100.3',
+    } as unknown as IncomingMessage & Parameters<typeof resolveClientIp>[0];
+
+    const ip2 = resolveClientIp(reqWithoutHeader);
+    expect(ip2).toBe('198.51.100.1');
+  });
+});

--- a/server/src/services/ipinfo.ts
+++ b/server/src/services/ipinfo.ts
@@ -1,0 +1,193 @@
+import type { Request } from 'express';
+
+const IPINFO_BASE_URL = 'https://ipinfo.io';
+const DEFAULT_TIMEOUT_MS = parseInt(process.env.IPINFO_TIMEOUT_MS ?? '3000', 10);
+const DEFAULT_CACHE_TTL_MS = parseInt(process.env.IPINFO_CACHE_TTL_MS ?? '300000', 10);
+
+interface IpInfoRawResponse {
+  ip: string;
+  city?: string;
+  region?: string;
+  country?: string;
+  loc?: string;
+  [key: string]: unknown;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  value: GeoLookupValue;
+}
+
+interface GeoLookupValue {
+  ip: string;
+  city?: string;
+  region?: string;
+  country?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface GeoLookupResult extends GeoLookupValue {
+  source: 'ipinfo';
+  cached: boolean;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+const privateIpMatchers = [
+  /^(::1|::ffff:127\.[0-9.]+)$/,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./,
+  /^0\.0\.0\.0$/,
+  /^localhost$/i,
+];
+
+const getNormalizedIp = (ip: string | undefined | null): string => {
+  if (!ip) return '';
+  const first = Array.isArray(ip) ? ip[0] : ip.split(',')[0];
+  const trimmed = first.trim();
+  return trimmed.startsWith('::ffff:') ? trimmed.replace('::ffff:', '') : trimmed;
+};
+
+const isPublicIp = (ip: string): boolean => {
+  if (!ip) return false;
+  return !privateIpMatchers.some((regex) => regex.test(ip));
+};
+
+const getCacheKey = (ip: string): string => ip;
+
+const getTimeout = (): number => {
+  return Number.isFinite(DEFAULT_TIMEOUT_MS) ? DEFAULT_TIMEOUT_MS : 3000;
+};
+
+const getCacheTtl = (): number => {
+  return Number.isFinite(DEFAULT_CACHE_TTL_MS) ? DEFAULT_CACHE_TTL_MS : 300000;
+};
+
+const extractLatLong = (loc?: string): { latitude?: number; longitude?: number } => {
+  if (!loc) return {};
+  const [lat, lon] = loc.split(',');
+  const latitude = Number.parseFloat(lat);
+  const longitude = Number.parseFloat(lon);
+  if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+    return { latitude, longitude };
+  }
+  return {};
+};
+
+const fetchWithTimeout = async (url: string, timeoutMs: number): Promise<Response> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const toGeoLookupValue = (raw: IpInfoRawResponse): GeoLookupValue => {
+  const { latitude, longitude } = extractLatLong(raw.loc);
+  return {
+    ip: raw.ip,
+    city: raw.city,
+    region: raw.region,
+    country: raw.country,
+    latitude,
+    longitude,
+  };
+};
+
+export const resolveClientIp = (req: Pick<Request, 'ip' | 'headers' | 'socket'>): string => {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  const forwardedValue = Array.isArray(forwardedFor)
+    ? forwardedFor[0]
+    : typeof forwardedFor === 'string'
+      ? forwardedFor
+      : undefined;
+  const candidate = getNormalizedIp(forwardedValue);
+
+  if (candidate) {
+    return candidate;
+  }
+
+  if (req.socket?.remoteAddress) {
+    return getNormalizedIp(req.socket.remoteAddress);
+  }
+
+  return getNormalizedIp(req.ip);
+};
+
+export const lookupIp = async (ipAddress: string): Promise<GeoLookupResult | null> => {
+  const ip = getNormalizedIp(ipAddress);
+
+  if (!ip || !isPublicIp(ip)) {
+    return null;
+  }
+
+  const token = process.env.IPINFO_TOKEN;
+  if (!token) {
+    return null;
+  }
+
+  const cacheKey = getCacheKey(ip);
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return {
+      ...cached.value,
+      source: 'ipinfo',
+      cached: true,
+    };
+  }
+
+  const timeoutMs = getTimeout();
+  const url = `${IPINFO_BASE_URL}/${encodeURIComponent(ip)}?token=${encodeURIComponent(token)}`;
+
+  try {
+    const response = await fetchWithTimeout(url, timeoutMs);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as IpInfoRawResponse;
+
+    if (!payload?.ip) {
+      return null;
+    }
+
+    const value = toGeoLookupValue(payload);
+    cache.set(cacheKey, {
+      expiresAt: now + getCacheTtl(),
+      value,
+    });
+
+    return {
+      ...value,
+      source: 'ipinfo',
+      cached: false,
+    };
+  } catch (error) {
+    if ((error as Error).name !== 'AbortError') {
+      console.warn('Failed to lookup IP info', error);
+    }
+
+    return null;
+  }
+};
+
+export const clearIpInfoCache = (): void => {
+  cache.clear();
+};
+
+export const setIpInfoCache = (ip: string, value: GeoLookupValue, ttlMs: number): void => {
+  cache.set(getCacheKey(ip), {
+    value,
+    expiresAt: Date.now() + ttlMs,
+  });
+};


### PR DESCRIPTION
Adds an ipinfo-backed geolocation service and middleware so Express requests include location context via res.locals.geo. Updates env examples and backend operations docs with IPINFO_TOKEN guidance for configuration.