### PR TITLE
docs: require PR workflow usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 
 ## GitHub Workflow Automation
 - Use `npm run gh:workflow` only when the branch is review-ready and automated checks have been run; the script opens, approves (if possible), merges, and cleans up the branch in one pass.
+- Do not push directly to `main`; every change must flow through a feature branch and the workflow automation so observers see a PR trail.
 - Provide a 2-6 sentence summary via `--summary` and optionally attach a Mermaid diagram with `--mermaid` to enrich the PR body.
 - Ensure `.env` (or the shell) supplies `GITHUB_TOKEN` and `GITHUB_REPOSITORY` so the GitHub CLI can authenticate without prompts.
 - The helper performs a squash merge into `main`; avoid running it for work that still needs peer review or multiple commits preserved.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 
 ### Automated PR Workflow
 - Run `npm run gh:workflow` only after local tests, linting, and docs are complete; the helper squash-merges directly into `main` and deletes the feature branch.
+- Never push commits directly to `main`; always land changes through a PR created by the workflow script so stakeholders can review the history.
 - Make sure `npm run lint` succeeds (calls both client and server lint scripts) before committing or opening a PR.
 - Required flags: `--branch`, `--commit`, `--title`, and `--summary` (must include 2-6 sentences). Optional `--mermaid "graph TD; ..."` appends a diagram to the PR body. Use `--base` to merge into a different branch when needed.
 - Environment: provide `GITHUB_TOKEN` (with `repo` scope) and `GITHUB_REPOSITORY=owner/name` via `.env` or the shell so the GitHub CLI can authenticate without prompts.

--- a/docs/codex-development.md
+++ b/docs/codex-development.md
@@ -19,7 +19,7 @@ This guide explains how to collaborate with Codex while building features in the
 - Use the root npm scripts as the canonical entry points (`npm run dev`, `npm run lint`, `npm run test`, `npm run test:coverage`). Specify workspaces if only one stack is affected.
 - Keep environment variables scoped: shared values in `.env`, frontend values with the `VITE_` prefix in `client/.env`, backend secrets in `server/.env`, and Supabase tooling keys in `supabase/.env`.
 - Update the matching `*.env.example` files whenever new variables become mandatory so Codex and teammates can sync quickly.
-- When automation is ready, run `npm run gh:workflow` with the required flags; skip it for exploratory or in-progress changes.
+- When automation is ready, run `npm run gh:workflow` with the required flags; skip it for exploratory or in-progress changes, and never bypass it with a direct push to `main`.
 
 ## Testing & Quality Gates
 - Default to running `npm run lint` plus the relevant workspace tests before handing work back to Codex or teammates.


### PR DESCRIPTION
Clarifies that every change must route through the GitHub workflow automation instead of direct pushes to main. Ensures contributors and observers see a consistent pull request trail.