### PR TITLE
docs: reinforce coverage obligations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,5 +60,5 @@
 - Explain modifications, note testing status (or why tests were skipped), and suggest natural next steps for the user.
 - Ensure `npm run lint` passes (client and server) before committing or handing off work.
 - Call out documentation updates or confirm that docs remain accurate after code changes.
-- Keep the coverage automation green: the workspace CI composes client and server vitest runs and fails when either coverage report drops below 80%; run the root `npm run test:coverage` gate locally before hand-off if coverage may shift.
+- Keep the coverage automation green: the workspace CI composes client and server vitest runs and fails when either coverage report drops below 80%; run the root `npm run test:coverage` gate locally before hand-off and add or adjust tests immediately if the threshold is missed.
 - Use the root scripts (`npm run test`, `npm run test:coverage`) to validate changes before hand-off when applicable.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Starter workspace for a TypeScript React + Express project. Follow the agent gui
 - `npm run build` — Run frontend and backend builds.
 - `npm run lint` — Type-check both projects.
 - `npm run test` — Execute workspace-level test commands.
-- `npm run test:coverage` — Compose client and server coverage reports; mirrors the CI gate that fails if either side drops below 80%.
+- `npm run test:coverage` — Compose client and server coverage reports; mirrors the CI gate that fails if either side drops below 80%. When coverage falls under 80%, write or update tests before moving forward.
 - `npm run dev:client` / `npm run dev:server` — Focus on a single stack during development.
 - `npm run gh:workflow -- --branch feature/example --commit "feat: add example" --title "feat: add example" --summary "Sentence one. Sentence two."` — Automate the GitHub workflow (branch switch/create, commit, PR creation with summary and optional Mermaid block, approval (best-effort), merge into `main`, and branch cleanup). Requires `gh` CLI plus `GITHUB_TOKEN` and `GITHUB_REPOSITORY` env vars.
 - `npm run analyze:playwright -- --url https://example.com` — Launch Chromium via Playwright to render a URL and emit an accessibility/layout summary (after `npx playwright install`).

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -19,7 +19,7 @@
 - Update `/README.md` if new frontend scripts or npm commands are introduced.
 - Keep client environment variables in `client/.env` using the `VITE_` prefix so Vite exposes them safely.
 - When adding or renaming frontend env vars, update `client/.env.example` with placeholder values so onboarding stays smooth.
-- CI enforces an 80% minimum for client coverage; run `npm run test:coverage --workspace client` before hand-off when changes could impact the gate.
+- CI enforces an 80% minimum for client coverage; run `npm run test:coverage --workspace client` before hand-off and expand or update tests immediately if coverage dips below 80%.
 
 ## Templates & Patterns
 - Start new components from `/docs/templates/component-pattern.md`; remove placeholder tokens before review.

--- a/docs/codex-development.md
+++ b/docs/codex-development.md
@@ -24,7 +24,7 @@ This guide explains how to collaborate with Codex while building features in the
 
 ## Testing & Quality Gates
 - Default to running `npm run lint` plus the relevant workspace tests before handing work back to Codex or teammates.
-- Use `npm run test:coverage` when changes may affect the CI coverage gate (80% minimum for both client and server).
+- Use `npm run test:coverage` when changes may affect the CI coverage gate (80% minimum for both client and server), and do not proceed until new or updated tests lift any side that falls under 80%.
 - For Playwright tasks, execute `npm run test --workspace playwright` or `npm run analyze:playwright` as appropriate and attach findings to hand-off notes.
 
 ## Documentation & Handoff

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -15,7 +15,7 @@
 - Ensure `/README.md` reflects new environment variables or scripts introduced for the backend.
 - Store backend environment variables in `server/.env`; keep secrets out of client-visible locations.
 - Maintain `server/.env.example` with the required keys and safe placeholder values whenever contracts change.
-- Coverage automation fails if backend coverage slips under 80%; run `npm run test:coverage --workspace server` ahead of review when edits might reduce the gate.
+- Coverage automation fails if backend coverage slips under 80%; run `npm run test:coverage --workspace server` ahead of review and create or update tests right away if the threshold is not met.
 
 ## Templates & Patterns
 - Use `/docs/templates/endpoint-handler.md` when scaffolding new controllers; replace placeholders before opening PRs.


### PR DESCRIPTION
Clarify in the README and agent guides that both client and server must maintain at least 80 percent coverage. Explicitly require adding or updating tests when coverage slips below the threshold to keep teams from proceeding with gaps. Coverage checks show the client at 100 percent while the server remains below 80 percent, signalling new backend tests are still needed.