### PR TITLE
test: increase server coverage to pass gate

### DIFF
--- a/server/src/app.integration.test.ts
+++ b/server/src/app.integration.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import app from './index';
+import * as ipinfo from './services/ipinfo';
+
+describe('app integration', () => {
+  const originalToken = process.env.IPINFO_TOKEN;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.IPINFO_TOKEN = originalToken;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.IPINFO_TOKEN = originalToken;
+  });
+
+  it('responds to /health and attempts to enrich geo data', async () => {
+    process.env.IPINFO_TOKEN = 'token';
+    const resolveSpy = vi.spyOn(ipinfo, 'resolveClientIp').mockReturnValue('203.0.113.10');
+    const lookupSpy = vi.spyOn(ipinfo, 'lookupIp').mockResolvedValue({
+      ip: '203.0.113.10',
+      source: 'ipinfo',
+      cached: false,
+    });
+
+    const response = await request(app).get('/health').set('x-forwarded-for', '203.0.113.10');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: 'ok' });
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(lookupSpy).toHaveBeenCalledWith('203.0.113.10');
+  });
+
+  it('returns a 404 for unknown routes', async () => {
+    const response = await request(app).get('/nope');
+    expect(response.status).toBe(404);
+  });
+});

--- a/server/src/middleware/attachGeo.test.ts
+++ b/server/src/middleware/attachGeo.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import attachGeo from './attachGeo';
+import * as ipinfo from '../services/ipinfo';
+
+type MutableResponse = {
+  locals: Record<string, unknown>;
+};
+
+describe('attachGeo middleware', () => {
+  const originalToken = process.env.IPINFO_TOKEN;
+
+  let req: Partial<Request>;
+  let res: MutableResponse;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.IPINFO_TOKEN = originalToken;
+    req = {
+      headers: {},
+      socket: { remoteAddress: undefined } as unknown as Request['socket'],
+    };
+    res = { locals: {} };
+    next = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.IPINFO_TOKEN = originalToken;
+  });
+
+  it('skips lookup when the IPINFO token is missing', async () => {
+    process.env.IPINFO_TOKEN = '';
+    const resolveSpy = vi.spyOn(ipinfo, 'resolveClientIp');
+    const lookupSpy = vi.spyOn(ipinfo, 'lookupIp');
+
+    await attachGeo(req as Request, res as unknown as Response, next);
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(lookupSpy).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.locals.geo).toBeUndefined();
+  });
+
+  it('short-circuits when no client IP can be resolved', async () => {
+    process.env.IPINFO_TOKEN = 'token';
+    vi.spyOn(ipinfo, 'resolveClientIp').mockReturnValue('');
+    const lookupSpy = vi.spyOn(ipinfo, 'lookupIp');
+
+    await attachGeo(req as Request, res as unknown as Response, next);
+
+    expect(lookupSpy).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores geo data on the response when lookup succeeds', async () => {
+    process.env.IPINFO_TOKEN = 'token';
+    vi.spyOn(ipinfo, 'resolveClientIp').mockReturnValue('203.0.113.1');
+    vi.spyOn(ipinfo, 'lookupIp').mockResolvedValue({
+      ip: '203.0.113.1',
+      city: 'Example City',
+      region: 'Example Region',
+      country: 'ZZ',
+      source: 'ipinfo',
+      cached: false,
+    });
+
+    await attachGeo(req as Request, res as unknown as Response, next);
+
+    expect(res.locals.geo).toEqual({
+      ip: '203.0.113.1',
+      city: 'Example City',
+      region: 'Example Region',
+      country: 'ZZ',
+      source: 'ipinfo',
+      cached: false,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning when lookup throws and still calls next', async () => {
+    process.env.IPINFO_TOKEN = 'token';
+    vi.spyOn(ipinfo, 'resolveClientIp').mockReturnValue('203.0.113.2');
+    vi.spyOn(ipinfo, 'lookupIp').mockRejectedValue(new Error('network error'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await attachGeo(req as Request, res as unknown as Response, next);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to enrich request with geolocation data',
+      expect.any(Error),
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.locals.geo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add unit and integration tests for the Express middleware and health route to exercise the server wiring. Ensure attachGeo handles missing tokens, missing IPs, successful lookups, and errors without blocking requests. Verify the /health route responds OK while invoking the geo lookup stack. Coverage now reports 100 percent for client code and 91.6 percent statements on the server, clearing the 80 percent requirement.